### PR TITLE
Make our own htpasswd

### DIFF
--- a/bin/make_htpasswd_user.sh
+++ b/bin/make_htpasswd_user.sh
@@ -2,8 +2,14 @@
 
 source .env
 mkdir -p auth
-docker run \
-  --entrypoint htpasswd \
-  registry -Bbn ${AUTH_HTPASSWD_USER} ${AUTH_HTPASSWD_PASS} >> auth/htpasswd
+cat >> apache-utils <<EOF
+FROM alpine
+RUN apk add apache2-utils
+EOF
+docker build -t htpasswd -f apache-utils .
+docker run --rm htpasswd htpasswd -Bbn ${AUTH_HTPASSWD_USER} ${AUTH_HTPASSWD_PASS} >> auth/htpasswd
+docker image rm htpasswd
+rm apache-utils
+
 
 exit 0


### PR DESCRIPTION
Looks like docker people decided to remove apache2-utils package from their image so we need an alternative for creating htpasswd file. This was the first solution that came to mind. Feel free to do with it what you want.